### PR TITLE
Update p.o. box filter for assign kits

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2822,7 +2822,7 @@ const processParticipantHomeMouthwashKitData = (record, printLabel) => {
         return null;
     }
 
-    const poBoxRegex = /^(?:P\.?O\.?\s*(?:Box|B\.?)?|Post\s+Office\s+(?:Box|B\.?)?)\s*(\s*#?\s*\d*)((?:\s+(.+))?$)$/i;
+    const poBoxRegex = /^(?:P\.?\s*O\.?\s*(?:Box|B\.?)?|Post\s+Office\s+(?:Box|B\.?)?)\s*(\s*#?\s*\d*)((?:\s+(.+))?$)$/i;
 
     const physicalAddressLineOne = record[physicalAddress1];
     let addressObj = {};


### PR DESCRIPTION
The PR is related to:
- https://github.com/episphere/connect/issues/1248

Original filter does not handle spacing after "p" for po box.

Code Change:
- added optional spacing after the P for regex matching