### PR TITLE
queryKitsByReceivedDate now finds and passes back kitLevel

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2716,7 +2716,7 @@ const queryReplacementHomeCollectionAddressesToPrint = async (limit) => {
 
 const queryKitsByReceivedDate = async (receivedDateTimestamp) => {
     try {
-        const biospecSnapshot = await db.collection('biospecimen').where('143615646.826941471', '==', receivedDateTimestamp).get();
+        const biospecSnapshot = await db.collection('biospecimen').where(`${fieldMapping.tubesBagsCids.mouthwashTube1}.${fieldMapping.receivedDateTime}`, '==', receivedDateTimestamp).get();
         // Because kitLevel is needed by this report and is stored only on the kitAssembly and not the biospecimen record
         // we must look up the corresponding kitAssembly records and match them up
         const kitIds = [];

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2720,15 +2720,14 @@ const queryKitsByReceivedDate = async (receivedDateTimestamp) => {
         // Because kitLevel is needed by this report and is stored only on the kitAssembly and not the biospecimen record
         // we must look up the corresponding kitAssembly records and match them up
         const kitIds = [];
-        const toReturn = [];
         const kitDict = {};
 
         biospecSnapshot.docs.forEach(document => {
+            // Store each data object in kitDict to match up to kit records later
             const data = document.data();
             const kitId = data[fieldMapping.uniqueKitID];
             kitDict[kitId] = data;
             kitIds.push(kitId);
-            toReturn.push(data);
         });
 
         // Find the corresponding kit using conceptIds.uniqueKitID values
@@ -2752,7 +2751,9 @@ const queryKitsByReceivedDate = async (receivedDateTimestamp) => {
 
         } while (kitSnapshot.size === maxSize);
 
-        return toReturn;
+        // Because there are no sorts on biospecSnapshot, we don't need to care about order,
+        // so just whatever order is returned here is fine
+        return Object.keys(kitDict).map(key => kitDict[key]);
     } catch (error) {
         return new Error(error);
     }


### PR DESCRIPTION
Backend work for [1302](https://github.com/episphere/connect/issues/1302). queryKitsByReceivedDate now finds the kitLevel, E.G. whether the kit is an initial kit, a first replacement kit or a second replacement kit, and passes it along. Because that data lives only in the associated kitAssembly record, this now involves querying related kits.