### PR TITLE
Fixes error handling for add and update kit data to be consistent with expectations and handling in biospecimen. 

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -655,7 +655,7 @@ const biospecimenAPIs = async (req, res) => {
         }
         catch (error) {
             console.error(error);
-            return res.status(500).json(getResponseJSON(error.message, 500));
+            return res.status(500).json({response: error.message || `${error}`, code: 500});
         }
     }
 
@@ -672,7 +672,7 @@ const biospecimenAPIs = async (req, res) => {
         }
         catch (error) {
             console.error(error);
-            return res.status(500).json(getResponseJSON(error.message, 500));
+            return res.status(500).json({response: error.message || `${error}`, code: 500});
         }
     }
     else if (api === 'collectionUniqueness'){

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2503,42 +2503,32 @@ const validateKitAssemblyData = async (data) => {
 }
 
 const addKitAssemblyData = async (data) => {
-    try {
-        await validateKitAssemblyData(data);
-        await db.collection('kitAssembly').add(data);
-        
-        return true;
-    }
-    catch(error){
-        console.error(error);
-        return new Error(error);
-    }
+    // No try/catch; that is handled in the biospecimen endpoint
+    await validateKitAssemblyData(data);
+    await db.collection('kitAssembly').add(data);
+    
+    return true;
 }
 
 
 const updateKitAssemblyData = async (data) => {
-    try {
-        await validateKitAssemblyData(data);
-        const snapshot = await db.collection('kitAssembly').where('687158491', '==', data['687158491']).get();
-        printDocsCount(snapshot, "updateKitAssemblyData");
+    // No try/catch; that is handled in the biospecimen endpoint
+    await validateKitAssemblyData(data);
+    const snapshot = await db.collection('kitAssembly').where('687158491', '==', data['687158491']).get();
+    printDocsCount(snapshot, "updateKitAssemblyData");
 
-        if (snapshot.empty) return false
-        const docId = snapshot.docs[0].id;
+    if (snapshot.empty) return false
+    const docId = snapshot.docs[0].id;
 
-        await db.collection('kitAssembly').doc(docId).update({
-            '194252513': data[fieldMapping.returnKitId],
-            '259846815': data[fieldMapping.collectionCupId],
-            '972453354': data[fieldMapping.returnKitTrackingNum],
-            '690210658': data[fieldMapping.supplyKitId],
-            '786397882': data[fieldMapping.collectionCardId]
-        });
-        
-        return true;
-    }
-    catch(error){
-        console.error(error);
-        return new Error(error);
-    }
+    await db.collection('kitAssembly').doc(docId).update({
+        '194252513': data[fieldMapping.returnKitId],
+        '259846815': data[fieldMapping.collectionCupId],
+        '972453354': data[fieldMapping.returnKitTrackingNum],
+        '690210658': data[fieldMapping.supplyKitId],
+        '786397882': data[fieldMapping.collectionCardId]
+    });
+    
+    return true;
 }
 
 const checkCollectionUniqueness = async (supplyId, collectionId, returnKitTrackingNumber, uniqueKitID) => {


### PR DESCRIPTION
Fixes error handling for add and update kit data to be consistent with expectations and handling in biospecimen. This change was made as a part of the cleanup work for [1133](https://github.com/episphere/connect/issues/1133) after realizing that several errors were not being returned as expected from the API. Changes:

firestore.js:
* Errors from addKitAssemblyData and updateKitAssemblyData are now thrown and not returned, preventing messages from being swallowed

biospecimen.js
* error cases in corresponding endpoints to above now return errors with explicit correct object formatting and account for possible lack of error.message

Tests done:
* Automatic tests re-run
* Tested reused kit IDs and tracking numbers on kitAssembly page and ensured that errors displayed correctly.