### PR TITLE
Prod error fix

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2715,48 +2715,51 @@ const queryReplacementHomeCollectionAddressesToPrint = async (limit) => {
 }
 
 const queryKitsByReceivedDate = async (receivedDateTimestamp) => {
-    try {
-        const biospecSnapshot = await db.collection('biospecimen').where(`${fieldMapping.tubesBagsCids.mouthwashTube1}.${fieldMapping.receivedDateTime}`, '==', receivedDateTimestamp).get();
-        // Because kitLevel is needed by this report and is stored only on the kitAssembly and not the biospecimen record
-        // we must look up the corresponding kitAssembly records and match them up
-        const kitIds = [];
-        const kitDict = {};
+    // No try/catch; this is already handled in the endpoint which uses this
+    const biospecSnapshot = await db.collection('biospecimen').where(`${fieldMapping.tubesBagsCids.mouthwashTube1}.${fieldMapping.receivedDateTime}`, '==', receivedDateTimestamp).get();
+    // Because kitLevel is needed by this report and is stored only on the kitAssembly and not the biospecimen record
+    // we must look up the corresponding kitAssembly records and match them up
+    const kitIds = [];
+    const kitDict = {};
 
-        biospecSnapshot.docs.forEach(document => {
-            // Store each data object in kitDict to match up to kit records later
-            const data = document.data();
-            const kitId = data[fieldMapping.uniqueKitID];
+    biospecSnapshot.docs.forEach(document => {
+        // Store each data object in kitDict to match up to kit records later
+        const data = document.data();
+        const kitId = data[fieldMapping.uniqueKitID];
+        if(kitId) {
             kitDict[kitId] = data;
             kitIds.push(kitId);
-        });
+        }
+    });
 
-        // Find the corresponding kit using conceptIds.uniqueKitID values
-        let kitSnapshot;
-        let start = 0;
+    // Find the corresponding kit using conceptIds.uniqueKitID values
+    let kitSnapshot;
+    let start = 0;
 
-        // Run this in chunks of 30 to avoid exceeding the max allowed size for IN queries if we have more than 30 kits
-        const maxSize = 30;
-        do {
-            let query = db.collection('kitAssembly')
-                .where(`${fieldMapping.uniqueKitID}`, 'in', kitIds.slice(start, Math.min(maxSize, kitIds.length)));
-            kitSnapshot = await query.get();
-            for (const doc of kitSnapshot.docs) {
-                // For each kit, attach the kitLevel to the kit data found
-                const kitData = doc.data();
-                const kitLevel = kitData?.[fieldMapping.kitLevel] || fieldMapping.initialKit;
-                const kitId = kitData[fieldMapping.uniqueKitID];
-                kitDict[kitId][fieldMapping.kitLevel] = kitLevel;
-            }
-            start += maxSize;
+    // Run this in chunks of 30 to avoid exceeding the max allowed size for IN queries if we have more than 30 kits
+    const maxSize = 30;
+    do {
+        const inArr = kitIds.slice(start, Math.min(maxSize, kitIds.length));
+        if(!inArr.length) {
+            break;
+        }
+        let query = db.collection('kitAssembly')
+            .where(`${fieldMapping.uniqueKitID}`, 'in', inArr);
+        kitSnapshot = await query.get();
+        for (const doc of kitSnapshot.docs) {
+            // For each kit, attach the kitLevel to the kit data found
+            const kitData = doc.data();
+            const kitLevel = kitData?.[fieldMapping.kitLevel] || fieldMapping.initialKit;
+            const kitId = kitData[fieldMapping.uniqueKitID];
+            kitDict[kitId][fieldMapping.kitLevel] = kitLevel;
+        }
+        start += maxSize;
 
-        } while (kitSnapshot.size === maxSize);
+    } while (kitSnapshot.size === maxSize);
 
-        // Because there are no sorts on biospecSnapshot, we don't need to care about order,
-        // so just whatever order is returned here is fine
-        return Object.keys(kitDict).map(key => kitDict[key]);
-    } catch (error) {
-        return new Error(error);
-    }
+    // Because there are no sorts on biospecSnapshot, we don't need to care about order,
+    // so just whatever order is returned here is fine
+    return Object.keys(kitDict).map(key => kitDict[key]);
 }
 
 const eligibleParticipantsForKitAssignment = async () => {


### PR DESCRIPTION
Fixes an issue where getKitsByReceivedDate would error if no kits received on the given date were found

Resolves an issue where errors in queryCountReplacementHomeCollectionAddressesToPrint were being swallowed and resulting in false 200 responses.

Changes:
* queryCountReplacementHomeCollectionAddressesToPrint no longer returns Error, as location calling it expects errors to be thrown. Try/catch block around this logic removed, as it is unnecessary.
* queryCountReplacementHomeCollectionAddressesToPrint checks for empty arrays before attempting to run IN query.
* queryCountReplacementHomeCollectionAddressesToPrint also runs a sanity check that unique kit ID exists before trying to use it as a key.