### PR TITLE
1020 support

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1195,10 +1195,9 @@ describe('biospecimen', async () => {
                         60000, 
                         'Date kit requested is within a minute of test completion'
                     );
-                    // console.log('updates', updates);
                     assert.deepEqual(clonedUpdates, {
-                        [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwashBL1}.${fieldToConceptIdMapping.kitType}`]: 976461859,
-                        [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwashBL1}.${fieldToConceptIdMapping.kitStatus}`]: 728267588
+                        [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwashBL1}.${fieldToConceptIdMapping.kitType}`]: fieldToConceptIdMapping.mouthwashKit,
+                        [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwashBL1}.${fieldToConceptIdMapping.kitStatus}`]: fieldToConceptIdMapping.initialized
                       },
                        `Kit status ${status} eligible for replacement kit`);
                 });
@@ -1224,10 +1223,9 @@ describe('biospecimen', async () => {
                     'Date kit requested is within a minute of test completion'
                 );
     
-                // console.log('updates', updates);
                 assert.deepEqual(clonedUpdates, {
-                    [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwash}.${fieldToConceptIdMapping.kitType}`]: 976461859,
-                    [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwash}.${fieldToConceptIdMapping.kitStatus}`]: 728267588,
+                    [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwash}.${fieldToConceptIdMapping.kitType}`]: fieldToConceptIdMapping.mouthwashKit,
+                    [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwash}.${fieldToConceptIdMapping.kitStatus}`]: fieldToConceptIdMapping.initialized,
                     [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bloodOrUrineCollectedTimestamp}`]: null
                     },
                     `Kit status pending eligible for initial kit`);
@@ -1276,10 +1274,9 @@ describe('biospecimen', async () => {
                     'Date kit requested is within a minute of test completion'
                 );
     
-                // console.log('updates', updates);
                 assert.deepEqual(clonedUpdates, {
-                    [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwash}.${fieldToConceptIdMapping.kitType}`]: 976461859,
-                    [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwash}.${fieldToConceptIdMapping.kitStatus}`]: 728267588,
+                    [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwash}.${fieldToConceptIdMapping.kitType}`]: fieldToConceptIdMapping.mouthwashKit,
+                    [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwash}.${fieldToConceptIdMapping.kitStatus}`]: fieldToConceptIdMapping.initialized,
                     [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bloodOrUrineCollectedTimestamp}`]: null
                     },
                     `Kit status ${status} eligible for initial kit`);
@@ -1394,10 +1391,9 @@ describe('biospecimen', async () => {
                         'Date kit requested is within a minute of test completion'
                     );
         
-                    // console.log('updates', updates);
                     assert.deepEqual(clonedUpdates, {
-                        [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwashBL2}.${fieldToConceptIdMapping.kitType}`]: 976461859,
-                        [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwashBL2}.${fieldToConceptIdMapping.kitStatus}`]: 728267588
+                        [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwashBL2}.${fieldToConceptIdMapping.kitType}`]: fieldToConceptIdMapping.mouthwashKit,
+                        [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwashBL2}.${fieldToConceptIdMapping.kitStatus}`]: fieldToConceptIdMapping.initialized
                       },
                        `Kit status ${status} eligible for replacement kit`);
                 });

--- a/test/test.js
+++ b/test/test.js
@@ -1161,7 +1161,6 @@ describe('biospecimen', async () => {
     });
 
     describe('getHomeMWKitData', () => {
-        // @TODO: Updates for new behavior for requesting initial kits
         describe('First replacement kit', () => {
             it('Should set a first replacement kit', () => {
                 const statuses = [

--- a/utils/dashboard.js
+++ b/utils/dashboard.js
@@ -188,7 +188,10 @@ const dashboard = async (req, res) => {
             }
             return res.status(500).json(getResponseJSON(err.message, 500));
         }
-    } else if (api === 'requestHomeMWReplacementKit') {
+    } else if (api === 'requestHomeMWReplacementKit' || api === 'requestHomeKit') {
+        // Keeping the requestHomeMWReplacementKit endpoint for outdated UIs
+        // but updating to use the newer more general purpose logic
+        // and newly named endpoint
         let body = req.body;
 
         if (req.method !== 'POST') {
@@ -199,14 +202,16 @@ const dashboard = async (req, res) => {
         if(!connectId) {
             return res.status(405).json(getResponseJSON('Missing connect ID!', 405));
         }
+
         try {
-            const {requestHomeMWReplacementKit} = require('./firestore');
-            await requestHomeMWReplacementKit(connectId);
+            const {requestHomeKit} = require('./firestore');
+            await requestHomeKit(connectId);
             return res.status(200).json(getResponseJSON('Success!', 200));
         } catch(err) {
             console.error('Error', err);
             return res.status(500).json(getResponseJSON(err && err.message ? err.message : err, 500));
         }
+
     } else {
         return res.status(404).json(getResponseJSON('API not found!', 404));
     }

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2911,32 +2911,6 @@ const requestHomeKit = async(connectId) => {
     });
 }
 
-const requestHomeMWReplacementKit = async (connectId) => {
-    return await db.runTransaction(async transaction => {
-        // First find the user
-        const participantQuery = db.collection('participants').where('Connect_ID', '==', connectId);
-        const participantSnapshot = await transaction.get(participantQuery);
-        if(!participantSnapshot.size) {
-            throw new Error('Could not find participant ' + connectId);
-        }
-        const data = participantSnapshot.docs[0].data();
-        
-        try {
-            if (data[fieldMapping.withdrawConsent] == fieldMapping.yes) {
-                throw new Error('Participant has withdrawn consent.');
-            } else if (data[fieldMapping.participantDeceasedNORC] == fieldMapping.yes) {
-                throw new Error('Participant is deceased.');
-            }
-            const updatedParticipantObject = getHomeMWKitData(data);
-            transaction.update(participantSnapshot.docs[0].ref, updatedParticipantObject);
-            return true;
-        } catch(err) {
-            console.error('Error getting participant replacement kit', err);
-            throw err;
-        }
-    });
-}
-
 const addKitStatusToParticipant = async (participantsCID) => {
     try {
         const { collectionDetails, baseline, bioKitMouthwash, kitStatus, addressPrinted } = fieldMapping;
@@ -4740,7 +4714,6 @@ module.exports = {
     addKitStatusToParticipantV2,
     markParticipantAddressUndeliverable,
     eligibleParticipantsForKitAssignment,
-    requestHomeMWReplacementKit,
     requestHomeKit,
     processSendGridEvent,
     processTwilioEvent,

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -3,7 +3,7 @@ const { Transaction, FieldPath, FieldValue, Filter } = require('firebase-admin/f
 admin.initializeApp();
 const db = admin.firestore();
 db.settings({ ignoreUndefinedProperties: true }); // Skip keys with undefined values instead of erroring
-const { tubeConceptIds, collectionIdConversion, swapObjKeysAndValues, batchLimit, listOfCollectionsRelatedToDataDestruction, createChunkArray, twilioErrorMessages, cidToLangMapper, printDocsCount, getFiveDaysAgoDateISO, getHomeMWReplacementKitData, processParticipantHomeMouthwashKitData, sanitizeObject } = require('./shared');
+const { tubeConceptIds, collectionIdConversion, swapObjKeysAndValues, batchLimit, listOfCollectionsRelatedToDataDestruction, createChunkArray, twilioErrorMessages, cidToLangMapper, printDocsCount, getFiveDaysAgoDateISO, getHomeMWKitData, processParticipantHomeMouthwashKitData, sanitizeObject } = require('./shared');
 const fieldMapping = require('./fieldToConceptIdMapping');
 const { isIsoDate } = require('./validation');
 const {getParticipantTokensByPhoneNumber} = require('./bigquery');
@@ -2604,27 +2604,66 @@ const participantHomeCollectionKitFields = [
 const queryHomeCollectionAddressesToPrint = async (limit) => {
     try {
         const { bioKitMouthwash, kitStatus, initialized,
-            collectionDetails, baseline, bloodOrUrineCollectedTimestamp } = fieldMapping;
+            collectionDetails, baseline, bloodOrUrineCollectedTimestamp, dateKitRequested } = fieldMapping;
 
         const fiveDaysAgoDateISO = getFiveDaysAgoDateISO();
 
         let query = db.collection('participants')
             .where(`${collectionDetails}.${baseline}.${bioKitMouthwash}.${kitStatus}`, '==', initialized)
-            .where(`${collectionDetails}.${baseline}.${bloodOrUrineCollectedTimestamp}`, '<=', fiveDaysAgoDateISO)
-            .orderBy(`${collectionDetails}.${baseline}.${bloodOrUrineCollectedTimestamp}`, 'desc');
-
-        if(limit) {
-            query = query.limit(Math.min(limit, 500));
-        }
+            .where(Filter.or(
+                Filter.where(`${collectionDetails}.${baseline}.${bloodOrUrineCollectedTimestamp}`, '<=', fiveDaysAgoDateISO),
+                Filter.where(`${collectionDetails}.${baseline}.${bloodOrUrineCollectedTimestamp}`, '==', null)
+            ));
+            // @TODO: Ooh, can we include this sort? Is this value going to be null for manually requested kits?
+            // Maybe we should consider explicitly setting this field to null or something if not already present
+            // when requesting a kit.
+            // .orderBy(`${collectionDetails}.${baseline}.${bloodOrUrineCollectedTimestamp}`, 'desc');
 
         const snapshot = await query.get();
 
         if (snapshot.size === 0) return [];
 
+        // @TODO: if the dateKitRequested value is set, move it to the top of the list and sort by it
+        // We do not do this in the query because sorting in FireStore removes any entries which 
+        // do not have a value set for the field being sorted by, which is the case for most of these entries
+
+        let manualRequests = [];
+        let otherEntries = [];
+        snapshot.docs.forEach(doc => {
+            const data = doc.data();
+            if(data?.[collectionDetails]?.[baseline]?.[bioKitMouthwash]?.[dateKitRequested]) {
+                manualRequests.push(data);
+            } else {
+                otherEntries.push(data);
+            }
+        });
+
+        manualRequests = manualRequests.sort((aData, bData) => {
+            const aDate = aData?.[collectionDetails]?.[baseline]?.[bioKitMouthwash]?.[dateKitRequested];
+            const bDate = bData?.[collectionDetails]?.[baseline]?.[bioKitMouthwash]?.[dateKitRequested];
+            if(aDate === bDate) {
+                return 0;
+            }
+            return aDate < bDate ? -1 : 1; // Oldest to newest
+        });
+
+        otherEntries = otherEntries.sort((aData, bData) => {
+            const aDate = aData?.[collectionDetails]?.[baseline]?.[bloodOrUrineCollectedTimestamp];
+            const bDate = bData?.[collectionDetails]?.[baseline]?.[bloodOrUrineCollectedTimestamp];
+            if(aDate === bDate) {
+                return 0;
+            }
+            return aDate > bDate ? -1 : 1; // Newest to oldest
+        });
 
         // If we have made it to this stage and there is a P.O. Box,
         // we allow it to show in the print labels list to avoid count discrepancies
-        const mappedResults = snapshot.docs.map(doc => processParticipantHomeMouthwashKitData(doc.data(), true, true));
+        let mappedResults = manualRequests.concat(otherEntries).map(doc => processParticipantHomeMouthwashKitData(doc, true, true));
+
+        // Because we are sorting our results ourselves, we have to do the limit here rather than in the query
+        if (limit && limit < mappedResults.length) {
+            mappedResults = mappedResults.slice(0, limit);
+        }
         return mappedResults;
     } catch (error) {
         throw new Error(`Error querying home collection addresses to print`, {cause: error});
@@ -2768,7 +2807,7 @@ const eligibleParticipantsForKitAssignment = async () => {
             db.collection("participants")
                 .where(`${collectionDetails}.${baseline}.${bioKitMouthwash}.${kitStatus}`, '==', addressPrinted)
                 .select(...participantHomeCollectionKitFields)
-                .orderBy(`${collectionDetails}.${baseline}.${bloodOrUrineCollectedTimestamp}`, 'desc')
+                // .orderBy(`${collectionDetails}.${baseline}.${bloodOrUrineCollectedTimestamp}`, 'desc')
                 .get(),
             // First replacement home MW kits
             db.collection("participants")
@@ -2786,7 +2825,8 @@ const eligibleParticipantsForKitAssignment = async () => {
         
         // Include the participants who have replacement kits
         // Sort order: oldest replacement kit requests should always be at the top
-        // and then all the regular ones
+        // Then the manually requested initial kits, oldest to newest by requested date
+        // and then all the regular ones, newest to oldest by blood/urine collected
 
         const sortedReplacements = []
             .concat(firstReplacementKitSnapshot.docs)
@@ -2802,13 +2842,42 @@ const eligibleParticipantsForKitAssignment = async () => {
                 return aVal < bVal ? -1 : 1; // Oldest to newest
             });
 
+        let manualRequests = [];
+        let otherEntries = [];
+        snapshot.docs.forEach(doc => {
+            const data = doc.data();
+            if(data?.[collectionDetails]?.[baseline]?.[bioKitMouthwash]?.[dateKitRequested]) {
+                manualRequests.push(doc);
+            } else {
+                otherEntries.push(doc);
+            }
+        })
+
+        manualRequests = manualRequests.sort((aData, bData) => {
+            const aDate = aData?.[collectionDetails]?.[baseline]?.[bioKitMouthwash]?.[dateKitRequested];
+            const bDate = bData?.[collectionDetails]?.[baseline]?.[bioKitMouthwash]?.[dateKitRequested];
+            if(aDate === bDate) {
+                return 0;
+            }
+            return aDate < bDate ? -1 : 1; // Oldest to newest
+        });
+
+        otherEntries = otherEntries.sort((aData, bData) => {
+            const aDate = aData?.[collectionDetails]?.[baseline]?.[bloodOrUrineCollectedTimestamp];
+            const bDate = bData?.[collectionDetails]?.[baseline]?.[bloodOrUrineCollectedTimestamp];
+            if(aDate === bDate) {
+                return 0;
+            }
+            return aDate > bDate ? -1 : 1; // Newest to oldest
+        });
 
         let allPts = sortedReplacements
-            .concat(snapshot.docs);
+            .concat(manualRequests)
+            .concat(otherEntries);
 
 
         if (allPts.length === 0) return [];
-        // Once we get to this stage, we want any PO Boxes which have made it this far far to appear
+        // Once we get to this stage, we want any PO Boxes which have made it this far to appear
         // so that they can manually be marked as undeliverable
         const mappedResults = allPts.map(doc => processParticipantHomeMouthwashKitData(doc.data(), false, true));
         return mappedResults.filter(result => result !== null);
@@ -2816,6 +2885,34 @@ const eligibleParticipantsForKitAssignment = async () => {
     } catch(error) {
         throw new Error('Error getting Eligible Kit Assignment Participants.', {cause: error});
     }
+}
+
+const requestHomeKit = async(connectId) => {
+    return await db.runTransaction(async transaction => {
+        // First find the user
+        const participantQuery = db.collection('participants').where('Connect_ID', '==', connectId);
+        const participantSnapshot = await transaction.get(participantQuery);
+        if(!participantSnapshot.size) {
+            throw new Error('Could not find participant ' + connectId);
+        }
+        const data = participantSnapshot.docs[0].data();
+        
+        try {
+            if (data[fieldMapping.withdrawConsent] == fieldMapping.yes) {
+                throw new Error('Participant has withdrawn consent.');
+            } else if (data[fieldMapping.participantDeceasedNORC] == fieldMapping.yes) {
+                throw new Error('Participant is deceased.');
+            }
+            // Do we need to copy over any other data? What other data do we need to set here?
+            const updatedParticipantObject = getHomeMWKitData(data);
+            console.log('updatedParticipantObject', JSON.stringify(updatedParticipantObject, null, '\t'));
+            transaction.update(participantSnapshot.docs[0].ref, updatedParticipantObject);
+            return true;
+        } catch(err) {
+            console.error('Error getting participant replacement kit', err);
+            throw err;
+        }
+    });
 }
 
 const requestHomeMWReplacementKit = async (connectId) => {
@@ -2835,7 +2932,7 @@ const requestHomeMWReplacementKit = async (connectId) => {
                 throw new Error('Participant is deceased.');
             }
             // Do we need to copy over any other data? What other data do we need to set here?
-            const updatedParticipantObject = getHomeMWReplacementKitData(data);
+            const updatedParticipantObject = getHomeMWKitData(data);
             transaction.update(participantSnapshot.docs[0].ref, updatedParticipantObject);
             return true;
         } catch(err) {
@@ -4649,6 +4746,7 @@ module.exports = {
     markParticipantAddressUndeliverable,
     eligibleParticipantsForKitAssignment,
     requestHomeMWReplacementKit,
+    requestHomeKit,
     processSendGridEvent,
     processTwilioEvent,
     getSpecimenAndParticipant,

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2614,16 +2614,12 @@ const queryHomeCollectionAddressesToPrint = async (limit) => {
                 Filter.where(`${collectionDetails}.${baseline}.${bloodOrUrineCollectedTimestamp}`, '<=', fiveDaysAgoDateISO),
                 Filter.where(`${collectionDetails}.${baseline}.${bloodOrUrineCollectedTimestamp}`, '==', null)
             ));
-            // @TODO: Ooh, can we include this sort? Is this value going to be null for manually requested kits?
-            // Maybe we should consider explicitly setting this field to null or something if not already present
-            // when requesting a kit.
-            // .orderBy(`${collectionDetails}.${baseline}.${bloodOrUrineCollectedTimestamp}`, 'desc');
 
         const snapshot = await query.get();
 
         if (snapshot.size === 0) return [];
 
-        // @TODO: if the dateKitRequested value is set, move it to the top of the list and sort by it
+        // If the dateKitRequested value is set, move it to the top of the list and sort by it
         // We do not do this in the query because sorting in FireStore removes any entries which 
         // do not have a value set for the field being sorted by, which is the case for most of these entries
 
@@ -2810,7 +2806,6 @@ const eligibleParticipantsForKitAssignment = async () => {
             db.collection("participants")
                 .where(`${collectionDetails}.${baseline}.${bioKitMouthwash}.${kitStatus}`, '==', addressPrinted)
                 .select(...participantHomeCollectionKitFields)
-                // .orderBy(`${collectionDetails}.${baseline}.${bloodOrUrineCollectedTimestamp}`, 'desc')
                 .get(),
             // First replacement home MW kits
             db.collection("participants")
@@ -2906,9 +2901,7 @@ const requestHomeKit = async(connectId) => {
             } else if (data[fieldMapping.participantDeceasedNORC] == fieldMapping.yes) {
                 throw new Error('Participant is deceased.');
             }
-            // Do we need to copy over any other data? What other data do we need to set here?
             const updatedParticipantObject = getHomeMWKitData(data);
-            console.log('updatedParticipantObject', JSON.stringify(updatedParticipantObject, null, '\t'));
             transaction.update(participantSnapshot.docs[0].ref, updatedParticipantObject);
             return true;
         } catch(err) {
@@ -2934,7 +2927,6 @@ const requestHomeMWReplacementKit = async (connectId) => {
             } else if (data[fieldMapping.participantDeceasedNORC] == fieldMapping.yes) {
                 throw new Error('Participant is deceased.');
             }
-            // Do we need to copy over any other data? What other data do we need to set here?
             const updatedParticipantObject = getHomeMWKitData(data);
             transaction.update(participantSnapshot.docs[0].ref, updatedParticipantObject);
             return true;

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -1132,7 +1132,6 @@ const getHomeMWKitData = (data) => {
 
     const requestedDT = new Date().toISOString();
 
-    // Do we need to copy over any other data? What other data do we need to set here?
     updatedParticipantObject = {...updatedParticipantObject,
         [[fieldPath, kitType].join('.')]: mouthwashKit,
         [[fieldPath, kitStatus].join('.')]: initialized,

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -1190,13 +1190,16 @@ const processParticipantHomeMouthwashKitData = (record, printLabel, includePOBox
     // First of all, determine which visit it is
     let visit = 'BL';
     let requestDate = record?.[collectionDetails]?.[baseline]?.[bioKitMouthwash]?.[dateKitRequested] || record[collectionDetails]?.[baseline]?.[bioKitMouthwash]?.[bloodOrUrineCollectedTimestamp];
+    const bl2Record = record?.[collectionDetails]?.[baseline]?.[bioKitMouthwashBL2];
+    const bl1Record = record?.[collectionDetails]?.[baseline]?.[bioKitMouthwashBL1];
 
-    if(record?.[collectionDetails]?.[baseline]?.[bioKitMouthwashBL2]) {
+
+    if(bl2Record) {
         visit = 'BL_2';
-        requestDate = record[collectionDetails][baseline][bioKitMouthwashBL2][dateKitRequested];
-    } else if (record?.[collectionDetails]?.[baseline]?.[bioKitMouthwashBL1]) {
+        requestDate = bl2Record[dateKitRequested];
+    } else if (bl1Record) {
         visit = 'BL_1';
-        requestDate = record[collectionDetails][baseline][bioKitMouthwashBL1][dateKitRequested];
+        requestDate = bl1Record[dateKitRequested];
     }
     const processedRecord = {
         first_name: record[firstName],

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -1141,6 +1141,36 @@ const getHomeMWKitData = (data) => {
     return updatedParticipantObject;
 }
 
+const replacementKitSort = (aData, bData) => {
+    const { bioKitMouthwashBL2, bioKitMouthwashBL1, collectionDetails, baseline, dateKitRequested } = fieldMapping;
+    const aDate = aData?.[collectionDetails]?.[baseline]?.[bioKitMouthwashBL2]?.[dateKitRequested] || aData?.[collectionDetails]?.[baseline]?.[bioKitMouthwashBL1]?.[dateKitRequested];
+    const bDate = bData?.[collectionDetails]?.[baseline]?.[bioKitMouthwashBL2]?.[dateKitRequested] || bData?.[collectionDetails]?.[baseline]?.[bioKitMouthwashBL1]?.[dateKitRequested];
+    if(aDate === bDate) {
+        return 0;
+    }
+    return aDate < bDate ? -1 : 1; // Oldest to newest
+}
+
+const manualRequestSort = (aData, bData) => {
+    const { bioKitMouthwash, collectionDetails, baseline, dateKitRequested } = fieldMapping;
+    const aDate = aData?.[collectionDetails]?.[baseline]?.[bioKitMouthwash]?.[dateKitRequested];
+    const bDate = bData?.[collectionDetails]?.[baseline]?.[bioKitMouthwash]?.[dateKitRequested];
+    if(aDate === bDate) {
+        return 0;
+    }
+    return aDate < bDate ? -1 : 1; // Oldest to newest
+}
+
+const standardHomeKitSort = (aData, bData) => {
+    const { collectionDetails, baseline, bloodOrUrineCollectedTimestamp } = fieldMapping;
+    const aDate = aData?.[collectionDetails]?.[baseline]?.[bloodOrUrineCollectedTimestamp];
+    const bDate = bData?.[collectionDetails]?.[baseline]?.[bloodOrUrineCollectedTimestamp];
+    if(aDate === bDate) {
+        return 0;
+    }
+    return aDate > bDate ? -1 : 1; // Newest to oldest
+}
+
 // Note: existing snake_casing follows through to BPTL CSV reporting. Do not update to camelCase without prior communication.
 const processParticipantHomeMouthwashKitData = (record, printLabel, includePOBoxes) => {
     const { collectionDetails, baseline, bioKitMouthwash, bioKitMouthwashBL1, bioKitMouthwashBL2,
@@ -2295,6 +2325,9 @@ module.exports = {
     cleanSurveyData,
     updateBaselineData,
     getHomeMWKitData,
+    replacementKitSort,
+    manualRequestSort,
+    standardHomeKitSort,
     processParticipantHomeMouthwashKitData,
     refusalWithdrawalConcepts,
     withdrawalConcepts,


### PR DESCRIPTION
Backend support for issue [1020](https://github.com/episphere/connect/issues/1020) - "Add 'Request a Kit' button on the SMDB (Biospecimen) - Part A"

Changes:

shared.js:
* getHomeMWReplacementKitData renamed to getHomeMWKitData to better reflect new functionality
* getHomeMWKitData now requests an initial kit when it receives a participant who has not yet been marked as eligible for an initial kit.
* Some firming up of existence checking when reading nested properties of objects.

dashboard.js
* requestHomeKit endpoint added
* getHomeMWReplacementKitData -> getHomeMWKitData rename reflected

firestore.js
* getHomeMWReplacementKitData -> getHomeMWKitData rename reflected
* queryHomeCollectionAddressesToPrint sorting updated to place manually requested replacement kits at the top of the list
* requestHomeMWReplacementKit replaced with requestHomeKit
* eligibleParticipantsForKitAssignment updated to place participants with manual home kit requests between replacement kit requests and system-generated initial kit requests

test.js:
* getHomeMWReplacementKitData -> getHomeMWKitData rename reflected
* getHomeMWKitData tests updated to reflect new behavior for requesting initial kits