### PR TITLE
Clean-up: Rm updateDHQReportViewedStatus from dashboard.js

### DIFF
--- a/utils/dashboard.js
+++ b/utils/dashboard.js
@@ -74,28 +74,6 @@ const dashboard = async (req, res) => {
             return res.status(500).json(getResponseJSON('An error occurred while retrieving the DHQ-HEI report. Please try again later.', 500));
         }
 
-    } else if (api === 'updateDHQReportViewedStatus') {
-        if (req.method !== 'POST') {
-            return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
-        }
-
-        const { uid, studyID, respondentUsername } = req.body;
-
-        if (!uid || !studyID || !respondentUsername) {
-            return res.status(400).json(getResponseJSON('Missing required body parameters: uid, studyID, and/or respondentUsername.', 400));
-        }
-
-        try {
-            const { updateDHQReportViewedStatus } = require('./dhq');
-            await updateDHQReportViewedStatus(uid, studyID, respondentUsername);
-
-            return res.status(200).json(getResponseJSON('DHQ report viewed status updated successfully.', 200));
-
-        } catch (error) {
-            console.error('Error updating DHQ report viewed status:', error);
-            return res.status(500).json(getResponseJSON('An error occurred while updating the DHQ report viewed status. Please try again later.', 500));
-        }
-
     } else if (api === 'getFilteredParticipants') {
         if (req.method !== 'GET') {
             return res.status(405).json(getResponseJSON('Only GET requests are accepted!', 405));


### PR DESCRIPTION
Related: https://github.com/episphere/connect/issues/1327

Rm updateDHQReportViewedStatusendpoint from dashboard.js. We will only update the report viewed status from participant actions in the PWA, so we don't use this endpoint in dashboard.js.