### PR TITLE
1306 Updates

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1312,7 +1312,7 @@ describe('biospecimen', async () => {
                 });
                 
             });
-            it('Should prevent a participant whose initial kitStatus is address undeliverable from obtaining a replacement', () => {
+            it('Should update a participant whose initial kitStatus is address undeliverable to initialized', () => {
                 const data = {
                     [fieldToConceptIdMapping.firstName]: 'First',
                     [fieldToConceptIdMapping.lastName]: 'Last',
@@ -1329,7 +1329,21 @@ describe('biospecimen', async () => {
                         }
                     }
                 };
-                expect(shared.getHomeMWKitData.bind(null, data)).to.throw(/Participant address information is invalid./);
+                const updates = shared.getHomeMWKitData(data);
+                const clonedUpdates = Object.assign({}, updates);
+                delete clonedUpdates[`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwash}.${fieldToConceptIdMapping.dateKitRequested}`];
+                assert.closeTo
+                    (+new Date(updates[`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwash}.${fieldToConceptIdMapping.dateKitRequested}`]),
+                    +new Date(), 
+                    60000, 
+                    'Date kit requested is within a minute of test completion'
+                );
+    
+                assert.deepEqual(clonedUpdates, {
+                    [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwash}.${fieldToConceptIdMapping.kitType}`]: fieldToConceptIdMapping.mouthwashKit,
+                    [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwash}.${fieldToConceptIdMapping.kitStatus}`]: fieldToConceptIdMapping.initialized,
+                    },
+                    `Kit status address undeliverable eligible for initial kit`);
             });
             it('Should throw error on unrecognized kitStatus for initial home MW kit', () => {
                 const data = {
@@ -1474,7 +1488,21 @@ describe('biospecimen', async () => {
                         }
                     }
                 };
-                expect(shared.getHomeMWKitData.bind(null, data)).to.throw(/Participant address information is invalid./);
+                const updates = shared.getHomeMWKitData(data);
+                const clonedUpdates = Object.assign({}, updates);
+                delete clonedUpdates[`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwashBL1}.${fieldToConceptIdMapping.dateKitRequested}`];
+                assert.closeTo
+                    (+new Date(updates[`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwashBL1}.${fieldToConceptIdMapping.dateKitRequested}`]),
+                    +new Date(), 
+                    60000, 
+                    'Date kit requested is within a minute of test completion'
+                );
+    
+                assert.deepEqual(clonedUpdates, {
+                    [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwashBL1}.${fieldToConceptIdMapping.kitType}`]: fieldToConceptIdMapping.mouthwashKit,
+                    [`${fieldToConceptIdMapping.collectionDetails}.${fieldToConceptIdMapping.baseline}.${fieldToConceptIdMapping.bioKitMouthwashBL1}.${fieldToConceptIdMapping.kitStatus}`]: fieldToConceptIdMapping.initialized
+                    },
+                    `Kit status address undeliverable eligible for replacement kit`);
             });
             it('Should throw error on unrecognized kitStatus for first replacement home MW kit', () => {
                 const data = {

--- a/utils/fileUploads.js
+++ b/utils/fileUploads.js
@@ -3,7 +3,7 @@ const Busboy = require("busboy");
 const { savePathologyReportNamesToFirestore, getUploadedPathologyReportNamesFromFirestore } = require("./firestore");
 
 const storage = new Storage();
-const tierStr = process.env.GCLOUD_PROJECT.split("-").slice(3, 5).join("-").toLowerCase();
+const tierStr = process.env.GCLOUD_PROJECT?.split("-").slice(3, 5).join("-").toLowerCase();
 const pathologyReports = "pathology-reports";
 
 async function awaitNewBucketReady(bucketName, maxRetries = 10, delayMs = 500) {

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -1083,7 +1083,11 @@ const getHomeMWKitData = (data) => {
             }
             case addressUndeliverable:
             {
-                throw new Error('Participant address information is invalid.');
+                // addressUndeliverable being passed in here means that
+                // the address has been corrected and the status should be updated
+                // to initialized
+                fieldPath = `${collectionDetails}.${baseline}.${bioKitMouthwashBL1}`;
+                break;
             }
             case shipped:
             case received:
@@ -1110,6 +1114,7 @@ const getHomeMWKitData = (data) => {
                 fieldPath = `${collectionDetails}.${baseline}.${bioKitMouthwash}`;
                 break;
             }
+            
             case initialized:
             case addressPrinted:
             case assigned: 
@@ -1118,7 +1123,10 @@ const getHomeMWKitData = (data) => {
             }
             case addressUndeliverable:
             {
-                throw new Error('Participant address information is invalid.');
+                // addressUndeliverable being passed in here means that
+                // the address has been corrected and the status should be updated
+                // to initialized
+                break;
             }
             case shipped:
             case received:


### PR DESCRIPTION
For [1306](https://github.com/episphere/connect/issues/1306)

Changes:
shared.js:
* Updated getHomeMWKitData behavior to handle addressUndeliverable by changing the status to initialized, according to the new behavior specified in test.js:
* Updated getHomeMWKitData tests to reflect new behavior for undeliverable addresses fileUploads.js:
* Added an existence check to fix an issue that was preventing npm test from running when process.env.GCLOUD_PROJECT was not set

Testing:
* Updated and ran test.js
* Requested an initial kit for a participant with an undeliverable address for the initial kit and verified the data updated appropriately, including completing the kit receipt workflow
* Requested a replacement kit for the same participant, marked the address as undeliverable, re-requested a replacement kit for the participant, and verified that the data updated appropriately