### PR TITLE
Add received time of cancer data

### DIFF
--- a/utils/fieldToConceptIdMapping.js
+++ b/utils/fieldToConceptIdMapping.js
@@ -320,6 +320,7 @@ module.exports = {
     occurrenceNumber: 793981056,
     cancerOccurrence: 637153953,
     cancerOccurrenceTimestamp: 345545422,
+    cancerDataReceivedTimestamp: 212274403,
     isCancerDiagnosis: 525972260,
     primaryCancerSiteObject: 740819233,
     primaryCancerSiteCategorical: 149205077,

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -1809,6 +1809,7 @@ const finalizeCancerOccurrenceData = (occurrenceData, participantToken, particip
         ...occurrenceData,
         [fieldMapping.occurrenceNumber]: mostRecentOccurrenceNum + 1,
         [fieldMapping.isCancerDiagnosis]: fieldMapping.yes,
+        [fieldMapping.cancerDataReceivedTimestamp]: new Date().toISOString(),
         'token': participantToken,
         'Connect_ID': participantConnectId,
     };


### PR DESCRIPTION
This PR adds received time to cancer data before saving to `cancerOccurrence` collection in Firestore, as requested in [issue#1293](https://github.com/episphere/connect/issues/1293).