### PR TITLE
Follow-up to testing feedback on 1370

### DIFF
--- a/utils/dashboard.js
+++ b/utils/dashboard.js
@@ -161,8 +161,8 @@ const dashboard = async (req, res) => {
             return res.status(200).json({data: {data, deleted}, code: 200});
           }
           catch(err) {
-            console.error('error', err);
-            return res.status(500).json({data: 'Error: ' + (err && err.toString ? err.toString() : err), code: 500});
+            console.error('Error in resetParticipantHelper', err);
+            return res.status(500).json({data: err && err.toString ? err.toString() : (err?.message || err), code: 500});
           }
           
         }

--- a/utils/fieldToConceptIdMapping.js
+++ b/utils/fieldToConceptIdMapping.js
@@ -251,7 +251,9 @@ module.exports = {
      replacementKit2: 772116457,
      withdrawConsent: 747006172,
      activityParticipantRefusal: 685002411,
+     allFutureSamples: 352996056, // Nested under activityParticipantRefusal
      baselineMouthwashSample: 277479354,
+     refusedAllFutureActivities: 906417725, // This is top-level and not nested like activityParticipantRefusal.allFutureSamples is
      bloodOrUrineCollected: 156605577,
      bloodOrUrineCollectedTimestamp: 740582332,
      baselineBloodOrUrineOrderPlaced: 880794013,

--- a/utils/sites.js
+++ b/utils/sites.js
@@ -352,6 +352,7 @@ const updateParticipantData = async (req, res, authObj) => {
         }
 
         // If participant consent is being withdrawn, data destroyed or participant deceased, remove their home MW kit stuff
+        // This includes participants who have refused mouthwash samples, all future samples, or all future activities
         // This is specifically only if the kit status is initialized or address undeliverable
         // it will otherwise be handled elsewhere
         if (
@@ -359,12 +360,19 @@ const updateParticipantData = async (req, res, authObj) => {
             flatDocData[fieldMapping.participantMap.destroyData] === fieldMapping.yes ||
             flatDocData[fieldMapping.participantDeceased] === fieldMapping.yes ||
             flatDocData[fieldMapping.participantDeceasedNORC] === fieldMapping.yes ||
+            flatDocData[fieldMapping.refusedAllFutureActivities] === fieldMapping.yes ||
+            flatDocData[`${fieldMapping.activityParticipantRefusal}.${fieldMapping.baselineMouthwashSample}`] === fieldMapping.yes ||
+            flatDocData[`${fieldMapping.activityParticipantRefusal}.${fieldMapping.allFutureSamples}`] === fieldMapping.yes ||
+
 
             // Check both the existing and incoming data for this
             flatUpdateObj[fieldMapping.withdrawConsent] === fieldMapping.yes || 
             flatUpdateObj[fieldMapping.participantMap.destroyData] === fieldMapping.yes ||
             flatUpdateObj[fieldMapping.participantDeceased] === fieldMapping.yes ||
-            flatUpdateObj[fieldMapping.participantDeceasedNORC] === fieldMapping.yes
+            flatUpdateObj[fieldMapping.participantDeceasedNORC] === fieldMapping.yes ||
+            flatUpdateObj[fieldMapping.refusedAllFutureActivities] === fieldMapping.yes ||
+            flatUpdateObj[`${fieldMapping.activityParticipantRefusal}.${fieldMapping.baselineMouthwashSample}`] === fieldMapping.yes ||
+            flatUpdateObj[`${fieldMapping.activityParticipantRefusal}.${fieldMapping.allFutureSamples}`] === fieldMapping.yes
 
         ) {
             if([fieldMapping.initialized, fieldMapping.addressUndeliverable].indexOf(flatDocData[`${fieldMapping.collectionDetails}.${fieldMapping.baseline}.${fieldMapping.bioKitMouthwash}.${fieldMapping.kitStatus}`]) > -1) {


### PR DESCRIPTION
Updated home MW workflow participant consent verification process to include refusing all future activities, all future samples, or baseline mouthwash sample.

Fixed an issue when updating participant addresses as undeliverable where some relevant fields were not being included in the select

Also updated participant reset functionality to fix an issue resetting participants who have more than 30 records of an associated metadata type to be deleted.

Changes:

dashboard.js:
* Updated resetUser to have better error reporting

fieldToConceptIDMapping.js
* Added two new concept IDs needed for validation to avoid hardcoding

firestore.js
* Updated reset participant logic to chunk deletion into sets of 30 if more than 30 records of one type are to be deleted
* Updated assignKitToParticipant to validate sample and activity refusal
* Updated markParticipantAddressUndeliverable to validate sample and activity refusal, and also updated select to include the relevant fields
* Updated confirmShipmentKit to validate sample and activity refusal and updated the wording on the returned message
* Updated storeKitReceipt to validate sample and activity refusal and updated the wording on the returned message

sites.js
* Updated updateParticipantData to validate sample and activity refusal alongside the other participant refusal and deceased status consideration relevant for home MW kits.