### PR TITLE
Dhq phase3 BigQuery Compatibility

### DIFF
--- a/test/integration/dhq.integration.test.js
+++ b/test/integration/dhq.integration.test.js
@@ -129,6 +129,33 @@ describe('DHQ Integration Tests', () => {
 
             expect(result).to.deep.equal({ success: true });
         });
+
+        it('should handle field name sanitization in end-to-end processing', () => {
+            // Test data with already sanitized field names (as would come from processAnalysisResultsCSV)
+            const testData = [
+                { 
+                    'Respondent ID': TEST_CONSTANTS.PARTICIPANT_IDS.DEFAULT, 
+                    'Energy_kcal': '2000',
+                    'Protein_total_g': '75.4',
+                    'star_Vitamin_A': '800',
+                    'field_123_field': '15.2',
+                    'calcium_mg': '1200'
+                }
+            ];
+            
+            const result = prepareDocumentsForFirestore(testData, TEST_CONSTANTS.STUDY_IDS.DEFAULT, 'analysisResults');
+            
+            // Verify document structure preserves sanitized field names
+            expect(result.documents).to.have.length(1);
+            expect(result.documents[0].id).to.equal(TEST_CONSTANTS.PARTICIPANT_IDS.DEFAULT);
+            
+            const data = result.documents[0].data;
+            expect(data).to.have.property('Energy_kcal', '2000');
+            expect(data).to.have.property('Protein_total_g', '75.4');
+            expect(data).to.have.property('star_Vitamin_A', '800');
+            expect(data).to.have.property('field_123_field', '15.2');
+            expect(data).to.have.property('calcium_mg', '1200');
+        });
     });
 
     describe('getProcessedRespondentIds', () => {

--- a/test/unit/dhq.test.js
+++ b/test/unit/dhq.test.js
@@ -158,8 +158,8 @@ describe('DHQ Unit Tests', () => {
                     ['participant1', {
                         'Q001': 'Yes',
                         'Q002': '2 cups',
-                        'dhq3StudyID': 'study_123',
-                    }],
+                        'dhq3StudyID': 'study_123'
+                    }]
                 ];
 
                 const result = dhqModule.prepareDocumentsForFirestore(testData, 'study_123', 'rawAnswers');
@@ -174,7 +174,7 @@ describe('DHQ Unit Tests', () => {
                 const testData = [{ 'Respondent ID': 'participant1' }];
 
                 expect(() => {
-                dhqModule.prepareDocumentsForFirestore(testData, 'study_123', 'invalidType');
+                    dhqModule.prepareDocumentsForFirestore(testData, 'study_123', 'invalidType');
                 }).to.throw('Invalid data type in prepareDocumentsForFirestore(): invalidType');
             });
         });
@@ -190,7 +190,7 @@ describe('DHQ Unit Tests', () => {
                 { input: false, expected: null },
                 { input: {}, expected: '_object Object_' },
                 { input: [], expected: '' },
-                { input: 'normal', expected: 'normal' },
+                { input: 'normal', expected: 'normal' }
             ];
 
             malformedInputs.forEach(testCase => {
@@ -202,9 +202,9 @@ describe('DHQ Unit Tests', () => {
         it('should handle invalid data types in document preparation', () => {
             const invalidData = [
                 { 'Respondent ID': 'participant1' }, // Missing required fields
-                { Energy: '2000' }, // Missing respondent ID
+                { 'Energy': '2000' }, // Missing respondent ID
                 null, // Null entry
-                undefined, // Undefined entry
+                undefined // Undefined entry
             ];
 
             expect(() => {
@@ -236,9 +236,9 @@ describe('DHQ Unit Tests', () => {
             const chunkSize = dhqModule.getDynamicChunkSize(largeArray);
             expect(chunkSize).to.be.a('number');
             expect(chunkSize).to.be.above(0);
-            });
+        });
 
-            it('should handle concurrent chunk size calculations', () => {
+        it('should handle concurrent chunk size calculations', () => {
             const testData = [{ test: 'data' }];
             const results = [];
 
@@ -249,10 +249,18 @@ describe('DHQ Unit Tests', () => {
 
             // All results should be consistent
             expect(results.every(size => size === results[0])).to.be.true;
-            });
+        });
 
-            it('should handle corrupted input data', () => {
-            const corruptedData = [{ 'Respondent ID': null }, { 'Respondent ID': undefined }, { 'Respondent ID': '' }, { 'Respondent ID': 0 }, { 'Respondent ID': false }, { 'Respondent ID': {} }, { 'Respondent ID': [] }];
+        it('should handle corrupted input data', () => {
+            const corruptedData = [
+                { 'Respondent ID': null },
+                { 'Respondent ID': undefined },
+                { 'Respondent ID': '' },
+                { 'Respondent ID': 0 },
+                { 'Respondent ID': false },
+                { 'Respondent ID': {} },
+                { 'Respondent ID': [] }
+            ];
 
             corruptedData.forEach(data => {
                 const result = dhqModule.createResponseDocID(data['Respondent ID']);
@@ -267,7 +275,7 @@ describe('DHQ Unit Tests', () => {
                 { dataSize: 100, minChunks: 1 },
                 { dataSize: 1500, minChunks: 2 },
                 { dataSize: 5000, minChunks: 3 },
-                { dataSize: 10000, minChunks: 5 },
+                { dataSize: 10000, minChunks: 5 }
             ];
 
             testScenarios.forEach(scenario => {
@@ -276,7 +284,7 @@ describe('DHQ Unit Tests', () => {
 
                 const chunks = [];
                 for (let i = 0; i < data.length; i += chunkSize) {
-                chunks.push(data.slice(i, i + chunkSize));
+                    chunks.push(data.slice(i, i + chunkSize));
                 }
 
                 // We get at least the minimum expected chunks
@@ -297,7 +305,7 @@ describe('DHQ Unit Tests', () => {
                 { memory: 800 * 1024 * 1024, expectedChunkSize: 1000 },
                 { memory: 1100 * 1024 * 1024, expectedChunkSize: 500 },
                 { memory: 1400 * 1024 * 1024, expectedChunkSize: 250 },
-                { memory: 1700 * 1024 * 1024, expectedChunkSize: 100 },
+                { memory: 1700 * 1024 * 1024, expectedChunkSize: 100 }
             ];
 
             memoryScenarios.forEach(scenario => {
@@ -322,7 +330,7 @@ describe('DHQ Unit Tests', () => {
         it('should preserve uid when overriding state in createNotStartedDHQParticipant', () => {
             const participantUtils = TestUtils.createMockParticipantData();
             const participant = participantUtils.createNotStartedDHQParticipant('participant123', {
-                state: { query: 'test-query', site: 'test-site' },
+                state: { query: 'test-query', site: 'test-site' }
             });
 
             // Verify uid is preserved, overrides are applied, and other fields are still present
@@ -335,7 +343,7 @@ describe('DHQ Unit Tests', () => {
         it('should preserve uid when overriding state in createStartedDHQParticipant', () => {
             const participantUtils = TestUtils.createMockParticipantData();
             const participant = participantUtils.createStartedDHQParticipant('participant456', {
-                state: { sessionId: 'session-789', device: 'mobile' },
+                state: { sessionId: 'session-789', device: 'mobile' }
             });
 
             // Verify uid is preserved, overrides are applied, and other fields are still present
@@ -348,7 +356,7 @@ describe('DHQ Unit Tests', () => {
         it('should preserve uid when overriding state in createCompletedDHQParticipant', () => {
             const participantUtils = TestUtils.createMockParticipantData();
             const participant = participantUtils.createCompletedDHQParticipant('participant789', {
-                state: { completionReason: 'normal', finalScore: 95 },
+                state: { completionReason: 'normal', finalScore: 95 }
             });
 
             // Verify uid is preserved, overrides are applied, and other fields are still present
@@ -362,7 +370,7 @@ describe('DHQ Unit Tests', () => {
             const participantUtils = TestUtils.createMockParticipantData();
             const participant = participantUtils.createNotStartedDHQParticipant('participant123', {
                 customField: 'custom-value',
-                [fieldMapping.dhq3StudyID]: 'override-study-id',
+                [fieldMapping.dhq3StudyID]: 'override-study-id'
             });
 
             // Verify uid is preserved, overrides are applied, and other fields are still present

--- a/utils/dhq.js
+++ b/utils/dhq.js
@@ -1324,6 +1324,8 @@ const prepareDocumentsForFirestore = (chunk, studyID, dataType) => {
  * Ensures valid column naming and prevents collisions
  */
 const sanitizeFieldName = (fieldName) => {
+    const originalFieldName = fieldName;
+    
     if (!fieldName || typeof fieldName !== 'string') {
         throw new Error(`Invalid field name: ${fieldName} (must be a non-empty string)`);
     }
@@ -1340,7 +1342,7 @@ const sanitizeFieldName = (fieldName) => {
     
     // Sanity check for empty string
     if (!fieldName) {
-        throw new Error(`Field name "${fieldName}" became empty after sanitization`);
+        throw new Error(`Field name "${originalFieldName}" became empty after sanitization`);
     }
     
     // Ensure field name starts with letter or underscore (BQ requirement)

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -751,7 +751,9 @@ const removeDocumentFromCollection = async (connectID, token, dhq3Username = nul
 
         // Collection query mappings. All remaining collections default to Connect_ID.
         const tokenCollections = new Set(['notifications', 'ssn']);
-        const dhqCollections = new Set(['dhqAnalysisResults', 'dhqDetailedAnalysis', 'dhqRawAnswers']);
+
+        // TODO: DHQ Data Destruction held for Aug 2025 release (final decisions & details TBD)
+        //const dhqCollections = new Set(['dhqAnalysisResults', 'dhqDetailedAnalysis', 'dhqRawAnswers']);
         
         for (const collection of listOfCollectionsRelatedToDataDestruction) {
             const query = db.collection(collection);
@@ -761,10 +763,11 @@ const removeDocumentFromCollection = async (connectID, token, dhq3Username = nul
             if (tokenCollections.has(collection)) {
                 snapshot = await query.where("token", "==", token).get();
 
-            } else if (dhqCollections.has(collection)) {
-                if (!dhq3Username) continue; // If dhq3Username is null, there's no DHQ data to destroy.
-                snapshot = await query.where(fieldMapping.dhq3Username.toString(), "==", dhq3Username).get();
-                
+            // TODO: DHQ Data Destruction held for next release (final decisions & details TBD)
+            // } else if (dhqCollections.has(collection)) {
+            //     if (!dhq3Username) continue; // If dhq3Username is null, there's no DHQ data to destroy.
+            //     snapshot = await query.where(fieldMapping.dhq3Username.toString(), "==", dhq3Username).get();
+            
             } else {
                 snapshot = await query.where("Connect_ID", "==", connectID).get();
             }


### PR DESCRIPTION
Related: https://github.com/episphere/connect/issues/1329

•Sanitize DHQ report keys across all reports for BigQuery Sync compatibility.
•Update `dhqDetailedAnalysis` data structure: pre-flatten data to question-based format for BigQuery sync compatibility.
•Remove DHQ Data Destruction (holding for Aug 2025 release, details TBD).
•Update tests for key sanitization and new dhqDetailedAnalysis data structure.

Tests:
<img width="157" height="40" alt="Screenshot 2025-07-25 at 2 41 01 PM" src="https://github.com/user-attachments/assets/463ee450-30f9-4775-8c09-e4c506487171" />
