### PR TITLE
Issue#1223 remove offset get boxes pagination

### DIFF
--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -71,7 +71,7 @@ const biospecimenAPIs = async (req, res) => {
         try {
             req.query.source = 'biospecimen';
             const { getFilteredParticipants } = require('./submission');
-            
+
             return await getFilteredParticipants(req, res, obj);
         } catch (error) {
             console.error('Error in getFilteredParticipants.', error);
@@ -623,14 +623,17 @@ const biospecimenAPIs = async (req, res) => {
         await updateTempCheckDate(siteAcronym);
         return res.status(200).json({message: 'Success!', code:200});
     }
-    else if (api === 'getBoxesPagination'){
+    else if (api === 'getBoxesPagination'){ // Make changes here
         if(req.method !== 'POST') {
             return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
         }
         const {getBoxesPagination} = require('./firestore');
         const requestData = req.body;
+        
+        console.log("🚀 ~ biospecimenAPIs ~ requestData:", requestData)
+
         let toReturn = await getBoxesPagination(siteCode, requestData);
-        return res.status(200).json({data: toReturn, code:200});
+        return res.status(200).json({ data: toReturn, code:200 });
     }
     else if(api === 'getNumBoxesShipped'){
         if(req.method !== 'POST') {
@@ -639,6 +642,7 @@ const biospecimenAPIs = async (req, res) => {
         const {getNumBoxesShipped} = require('./firestore');
         const requestData = req.body;
         let response = await getNumBoxesShipped(siteCode, requestData);
+        console.log("🚀 ~ biospecimenAPIs ~ response:", response)
         return res.status(200).json({data:response, code:200});
     }
 

--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -623,17 +623,20 @@ const biospecimenAPIs = async (req, res) => {
         await updateTempCheckDate(siteAcronym);
         return res.status(200).json({message: 'Success!', code:200});
     }
-    else if (api === 'getBoxesPagination'){ // Make changes here
+    else if (api === 'getBoxesPagination'){
         if(req.method !== 'POST') {
             return res.status(405).json(getResponseJSON('Only POST requests are accepted!', 405));
         }
         const {getBoxesPagination} = require('./firestore');
         const requestData = req.body;
-        
-        console.log("🚀 ~ biospecimenAPIs ~ requestData:", requestData)
 
-        let toReturn = await getBoxesPagination(siteCode, requestData);
-        return res.status(200).json({ data: toReturn, code:200 });
+        try {
+            let toReturn = await getBoxesPagination(siteCode, requestData);
+            return res.status(200).json({ data: toReturn, code:200 });
+        } catch (error) {
+            console.error("🚀 ~ biospecimenAPIs ~ error:", error);
+            return res.status(500).json(getResponseJSON(error.message || `${error}`, 500));
+        }
     }
     else if(api === 'getNumBoxesShipped'){
         if(req.method !== 'POST') {

--- a/utils/biospecimen.js
+++ b/utils/biospecimen.js
@@ -634,7 +634,7 @@ const biospecimenAPIs = async (req, res) => {
             let toReturn = await getBoxesPagination(siteCode, requestData);
             return res.status(200).json({ data: toReturn, code:200 });
         } catch (error) {
-            console.error("🚀 ~ biospecimenAPIs ~ error:", error);
+            console.error('Error in getBoxesPagination:', error);
             return res.status(500).json(getResponseJSON(error.message || `${error}`, 500));
         }
     }
@@ -644,9 +644,13 @@ const biospecimenAPIs = async (req, res) => {
         }
         const {getNumBoxesShipped} = require('./firestore');
         const requestData = req.body;
-        let response = await getNumBoxesShipped(siteCode, requestData);
-        console.log("🚀 ~ biospecimenAPIs ~ response:", response)
-        return res.status(200).json({data:response, code:200});
+        try {
+            let response = await getNumBoxesShipped(siteCode, requestData);
+            return res.status(200).json({data:response, code:200});
+        } catch (error) {
+            console.error('Error in getNumBoxesShipped:', error);
+            return res.status(500).json(getResponseJSON(error.message || `${error}`, 500));
+        }
     }
 
     else if (api === 'addKitData'){

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -7,6 +7,7 @@ const { tubeConceptIds, collectionIdConversion, swapObjKeysAndValues, batchLimit
 const fieldMapping = require('./fieldToConceptIdMapping');
 const { isIsoDate } = require('./validation');
 const {getParticipantTokensByPhoneNumber} = require('./bigquery');
+const { submit } = require('./submission');
 
 const nciCode = 13;
 const nciConceptId = `517700004`;
@@ -2392,13 +2393,15 @@ const getBoxesPagination = async (siteCode, body) => {
 
                     if (remainingElements !== 0) {
                         elementsPerLastPage = remainingElements; // use the remaining elements for the last page
+                    } else if (numberOfBoxes > 0) {
+                        elementsPerLastPage = elementsPerPage; // assign elementsPerPage in case of no remainder and at least one box
                     }
 
                     query = query
                         .orderBy(orderByField, 'asc')
                         .limit(elementsPerLastPage)
                 } catch (error) {
-                    throw new Error(`Error fetching number of boxes shipped`);
+                    throw new Error(`Error fetching number of boxes shipped in getNumBoxesShipped: ${error.message}`, { cause: error });
                 }
             } 
         } else { // initial load no pagination
@@ -2425,8 +2428,8 @@ const getBoxesPagination = async (siteCode, body) => {
 
         return {
             boxes: result,
-            firstDocId: snapshot.docs[0].id || null, // Get the first document ID for pagination
-            lastDocId: snapshot.docs[snapshot.docs.length - 1].id || null, // Get the last document ID for pagination
+            firstDocId: docs[0].id || null, // Get the first document ID for pagination
+            lastDocId: docs[docs.length - 1].id || null, // Get the last document ID for pagination
         }
     } catch (error) {
         console.error(error);

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2333,7 +2333,7 @@ const buildQueryWithFilters = (query, trackingId, endDate, startDate, source, si
 
 const getBoxesPagination = async (siteCode, body) => {
     const currPage = body.pageNumber;
-    const orderByField = body.orderBy;
+    const orderByField = body.orderBy; // fieldMapping.submitShipmentTimestamp
     const elementsPerPage = body.elementsPerPage;
     const filters = body.filters ?? ``;
     const source = body.source ?? ``;

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2344,7 +2344,7 @@ const getBoxesPagination = async (siteCode, body) => {
     const firstDocId = body.firstDocId;
     const lastDocId = body.lastDocId;
     const paginationDirection = body.paginationDirection;
-    const paginationButtons = ['first', 'prev', 'next', 'last'];
+    const validDirections = ['first', 'prev', 'next', 'last'];
 
     const emptyResult = {
         boxes: [],
@@ -2357,7 +2357,7 @@ const getBoxesPagination = async (siteCode, body) => {
         query = preQueryBuilder(filters, query, trackingId, endDate, startDate, source, siteCode);
         
         // check for directional pagination
-        if (paginationDirection && paginationButtons.includes(paginationDirection)) {
+        if (paginationDirection && validDirections.includes(paginationDirection)) {
             if (paginationDirection === 'first') {
                 query = query
                     .orderBy(orderByField, 'desc')

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2441,7 +2441,7 @@ const getNumBoxesShipped = async (siteCode, body) => {
     const trackingId = filters.trackingId ?? ``;
     const endDate = filters.endDate ?? ``;
     try {
-        let query = db.collection('boxes').where('145971562', '==', 353358909); // TODO: replace hardcoded values
+        let query = db.collection('boxes').where(`${fieldMapping.submitShipmentFlag}`, '==', fieldMapping.yes);
         query = preQueryBuilder(filters, query, trackingId, endDate, startDate, source, siteCode);
         const snapshot = await query.count().get();
         return snapshot.data().count;

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -2450,7 +2450,7 @@ const getNumBoxesShipped = async (siteCode, body) => {
         return snapshot.data().count;
     } catch (error) {
         console.error(error);
-        return new Error(error)
+        throw error;
     }
 }
 


### PR DESCRIPTION
The [issue#1223 ](https://github.com/episphere/connect/issues/1223) is linked to 
- https://github.com/NCI-C4CP/biospecimen/pull/855
- https://github.com/episphere/connect/issues/1176

Request Changes:
-  refactor `getBoxesPagination()` using offset, to reduce and limit the costs of firebase reads
 - Problem with offset, this approach still incurs a cost and reads the documents skipped
 - Use [cursor](https://firebase.google.com/docs/firestore/query-data/query-cursors) instead as a marker for pagination

Code Changes:
- updated `getBoxesPagination()` function to accept paginationDirection
- added control flow using paginationDirection value and documentId markers to return shipped boxes
- added `try...catch` conditional endpoints