### PR TITLE
1211/1296/1381 fix

### DIFF
--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -1574,7 +1574,7 @@ const storeSpecimen = async (data) => {
 
 const submitSpecimen = async (biospecimenData, participantData, siteTubesList) => {
     const { checkDerivedVariables, processMouthwashEligibility } = require('./validation');
-    const { buildStreckPlaceholderData, updateBaselineData } = require('./shared');
+    const { buildStreckPlaceholderData, updateBaselineData, getAddedStrayTubes } = require('./shared');
 
     // Get the existing participant data (necessary for data reconciliation purposes)
     const siteCode = participantData[fieldMapping.healthCareProvider];
@@ -1602,11 +1602,37 @@ const submitSpecimen = async (biospecimenData, participantData, siteTubesList) =
         const participantDocRef = participantSnapshot.docs[0].ref;
         const participantSnapshotData = participantSnapshot.docs[0].data();
         const specimenDocRef = specimenCollectionSnapshot.docs[0].ref;
+        const specimenSnapshotData = specimenCollectionSnapshot.docs[0].data();
 
         // If necessary, update the biospecimenData to have the correct Streck placeholder data
         if (!biospecimenData[fieldMapping.tubesBagsCids.streckTube]) { // Check for streck data due to intermittent null streck values in Firestore (11/2023).
             const { buildStreckPlaceholderData } = require('./shared');
             buildStreckPlaceholderData(biospecimenData[fieldMapping.collectionId], biospecimenData[fieldMapping.tubesBagsCids.streckTube] = {});
+        }
+
+
+        // If specimen has not been finalized, finalize it as normal.
+        // Occasionally, a stray tube is found and an already-finalized collection gets updated. In this case, don't update the properties associated with finalizing.
+        const isPreviouslyFinalized = specimenSnapshotData[fieldMapping.collectionIsFinalized] === fieldMapping.yes;
+        if (!isPreviouslyFinalized) {
+            // This logic was moved here from the front end for increased stability
+            biospecimenData[fieldMapping.collectionIsFinalized] = fieldMapping.yes;
+            biospecimenData[fieldMapping.collectionFinalizedTimestamp] = new Date().toISOString();
+            biospecimenData[fieldMapping.boxedStatus] = fieldMapping.notBoxed;
+            biospecimenData[fieldMapping.strayTubesList] = [];
+        } else {
+            // If the specimen has already been finalized, make sure to update the stray tubes list and boxed status
+            // (This code was previously only in onContinue and leading to missing stray tubes
+            // when the continue button was not clicked at the right time. (Issues 1211, 1296, 1381))
+            const currentBoxedStatus = specimenSnapshotData[fieldMapping.boxedStatus];
+            if (currentBoxedStatus === fieldMapping.partiallyBoxed || currentBoxedStatus === fieldMapping.boxed) {
+                const addedStrayTubes = getAddedStrayTubes(specimenSnapshotData, biospecimenData);
+                const strayTubesList = biospecimenData[fieldMapping.strayTubesList] || [];
+                strayTubesList.push(...addedStrayTubes);
+                biospecimenData[fieldMapping.strayTubesList] = strayTubesList;
+                // If somehow we get here without added stray tubes, do not update the boxed status
+                biospecimenData[fieldMapping.boxedStatus] = addedStrayTubes.length ? fieldMapping.partiallyBoxed : specimenSnapshotData[fieldMapping.boxedStatus];
+            }
         }
 
         // Run the transaction
@@ -1720,7 +1746,7 @@ const getSpecimensByBoxedStatus = async (siteCode, boxedStatusConceptId, isBPTL 
 
 /**
  * Add a bag to the box. Orphan tubes are treated as separate bags.
- * Also manage/update/maintain the specimen doc's boxedStatus and strayTubeArray fields.
+ * Also manage/update/maintain the specimen doc's boxedStatus and  strayTubeArray fields.
  * @param {string} id - id of the box to update.
  * @param {object} boxAndTubesData - data package to update the box and specimen doc.
  * @param {array<string>} addedTubes - array of collectionIds of the tubes to add to the box. Format: `${collectionId} ${tubeType}`

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -1046,6 +1046,45 @@ const updateBaselineData = (biospecimenData, participantData, siteTubesList) => 
 }
 
 /**
+ * Matches function used on front end in biospecimen
+ * Used to determine stray tubes being added to an already finalized collection
+ * 
+ * @param {object} originalSpecimenData Original biospecimen object
+ * @param {object} currentSpecimenData Incoming biospecimen object updates
+ * @returns {array} Array of stray tube IDs
+ */
+const getAddedStrayTubes = (originalSpecimenData, currentSpecimenData) => {
+    const tubeCidList = [
+    '299553921',
+    '703954371',
+    '838567176',
+    '454453939',
+    '652357376',
+    '973670172',
+    '143615646',
+    // '787237543' and '223999569' are used as containers for tubes
+    '376960806',
+    '232343615',
+    '589588440',
+    '958646668',
+    '677469051',
+    '683613884',
+    '505347689',
+  ];
+    const originalCollectedTubesSet = new Set(
+        Object.keys(originalSpecimenData).filter(key =>
+            tubeCidList.includes(key) && originalSpecimenData[key][fieldMapping.tubeIsCollected] === fieldMapping.yes
+        )
+    );
+
+    return Object.keys(currentSpecimenData).filter(key =>
+        tubeCidList.includes(key) &&
+        currentSpecimenData[key][fieldMapping.tubeIsCollected] === fieldMapping.yes &&
+        !originalCollectedTubesSet.has(key)).map(tubeKey => currentSpecimenData[tubeKey][fieldMapping.objectId]
+    );
+}
+
+/**
  * Broken into a separate helper function for easier testing
  */
 const getHomeMWKitData = (data) => {
@@ -2342,6 +2381,7 @@ module.exports = {
     bagConceptIDs,
     cleanSurveyData,
     updateBaselineData,
+    getAddedStrayTubes,
     getHomeMWKitData,
     replacementKitSort,
     manualRequestSort,


### PR DESCRIPTION
Fixes an issue where the logic to add stray tubes to a finalized biospecimen was not always running on submission. This issue seems to have been behind tickes 1211, 1296 and 1381.

Changes:

shared.js:
* Added getAddedStrayTubes util function for use in identifying stray tubes being added to a collection

firestore.js:
* submitSpecimen updated to handle some finalization logic that was previously done on the front end and was sometimes skipped. This includes finalization date and time, box status, and stray tubes handling.