### PR TITLE
Return a different code and the provider id if the validatePin finds a non enrolling user

### DIFF
--- a/utils/fieldToConceptIdMapping.js
+++ b/utils/fieldToConceptIdMapping.js
@@ -51,6 +51,7 @@ module.exports = {
     duplicate: 922622075,
     cannotBeVerified: 219863910,
     outreachTimeOut: 160161595,
+    noLongerEnrolling: 290379732,
     collectionId: 820476880,
     temperatureProbeInBox: 105891443,
     boxTrackingNumberScan: 959708259,

--- a/utils/firestore.js
+++ b/utils/firestore.js
@@ -66,7 +66,7 @@ const verifyToken = async ({ token }) => {
 
 const verifyPin = async (pin) => {
     try {
-        const resultObj = { isDuplicateAccount: false, isValid: false, docId: null };
+        const resultObj = { isDuplicateAccount: false, isValid: false, docId: null, noLongerEnrolling: false, healthCareProvider: null };
         if (!pin) return resultObj;
 
         const snapshot = await db.collection('participants').where('pin', '==', pin).get();
@@ -80,10 +80,17 @@ const verifyPin = async (pin) => {
                 return resultObj;
             }
 
+            if (participantData[fieldMapping.verificationStatus] === fieldMapping.noLongerEnrolling) {
+                resultObj.noLongerEnrolling = true;
+                resultObj.healthCareProvider = participantData[fieldMapping.healthCareProvider];
+                return resultObj;
+            }
+
             if (participantData.state.uid === undefined) {
                 resultObj.isValid = true;
                 resultObj.docId = snapshot.docs[0].id;
             }
+
         }
 
         return resultObj;

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -2240,12 +2240,12 @@ const getTemplateForEmailLink = (
 const nihMailbox = 'NCIConnectStudy@mail.nih.gov'
 
 const getSecret = async (key) => {
-    const client = new SecretManagerServiceClient();
-    const [version] = await client.accessSecretVersion({
-        name: key,
-    });
-    const payload = version.payload.data.toString();
-    return payload;
+    // const client = new SecretManagerServiceClient();
+    // const [version] = await client.accessSecretVersion({
+    //     name: key,
+    // });
+    // const payload = version.payload.data.toString();
+    // return payload;
 };
 
 const cidToLangMapper = {

--- a/utils/shared.js
+++ b/utils/shared.js
@@ -2240,12 +2240,12 @@ const getTemplateForEmailLink = (
 const nihMailbox = 'NCIConnectStudy@mail.nih.gov'
 
 const getSecret = async (key) => {
-    // const client = new SecretManagerServiceClient();
-    // const [version] = await client.accessSecretVersion({
-    //     name: key,
-    // });
-    // const payload = version.payload.data.toString();
-    // return payload;
+    const client = new SecretManagerServiceClient();
+    const [version] = await client.accessSecretVersion({
+        name: key,
+    });
+    const payload = version.payload.data.toString();
+    return payload;
 };
 
 const cidToLangMapper = {

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -90,7 +90,7 @@ const validatePin = async (res, body, uid) => {
             return res.status(202).json(getResponseJSON('Duplicate account', 202));
 
         } else if (noLongerEnrolling) {
-            return res.status(204).json(getResponseJSON(healthCareProvider, 204));
+            return res.status(286).json(getResponseJSON(healthCareProvider, 286));
         } else if (isValid) {
             const linkAccountResponse = await linkInvitationRecordWithParticipantUID(docId, pin, firstSignInTimestamp, uid);
             if (linkAccountResponse instanceof Error) {

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -84,11 +84,13 @@ const validatePin = async (res, body, uid) => {
             return res.status(400).json(getResponseJSON('Bad request: firstSignInTimestamp required and must be an ISO 8601 timestamp', 400));
         }
 
-        const { isDuplicateAccount, isValid, docId } = await verifyPin(pin);
+        const { isDuplicateAccount, isValid, docId, noLongerEnrolling, healthCareProvider } = await verifyPin(pin);
 
         if (isDuplicateAccount) {
             return res.status(202).json(getResponseJSON('Duplicate account', 202));
 
+        } else if (noLongerEnrolling) {
+            return res.status(204).json(getResponseJSON(healthCareProvider, 204));
         } else if (isValid) {
             const linkAccountResponse = await linkInvitationRecordWithParticipantUID(docId, pin, firstSignInTimestamp, uid);
             if (linkAccountResponse instanceof Error) {


### PR DESCRIPTION
This is a companion to issue 1423: https://github.com/episphere/connect/issues/1423