### PR TITLE
Updated retrieveNotifications

### DIFF
--- a/utils/notifications.js
+++ b/utils/notifications.js
@@ -194,10 +194,9 @@ const retrieveNotifications = async (req, res, uid) => {
   }
 
   const { retrieveUserNotifications } = require("./firestore");
-
   try {
     const notificationArray = await retrieveUserNotifications(uid);
-    if (notificationArray.length > 0) {
+    if (notificationArray.length > 0 && req.query.markasread === 'true') {
       markAllNotificationsAsAlreadyRead(
         notificationArray.map((notification) => notification.id),
         "notifications"


### PR DESCRIPTION
The retrieveNotifications will now only update the read status if requested via a query parameter